### PR TITLE
fix the delay when loading the dashboard

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -387,7 +387,7 @@ export default {
       this.isAndroid = navigator.userAgent.match(/Android/i);
     } else if ((this.parameters().god || "").length !== 0) {
       this.mode = "god";
-      this.intervalHandler = window.setInterval(
+      this.intervalHandler = this.executeAndSetInterval(
         function () {
           this.getProblem();
         }.bind(this),
@@ -395,7 +395,7 @@ export default {
       );
     } else {
       this.mode = "dashboard";
-      this.intervalHandler = window.setInterval(
+      this.intervalHandler = this.executeAndSetInterval(
         function () {
           this.getStatus();
         }.bind(this),
@@ -577,6 +577,12 @@ export default {
       if (result.length !== 0) return result[0].name;
       else return "";
     },
+    executeAndSetInterval(callback, regularInterval) {
+      callback();
+      return setInterval(function () {
+        callback();
+      }, regularInterval);
+    }
   },
 };
 </script>


### PR DESCRIPTION
I noticed a 5-second delay every time the dashboard page loads, as shown in the video below:

[`5-second delay demonstration`](
https://github.com/user-attachments/assets/7caa15a5-f1c9-4595-b12b-db54856693d2
)

Upon inspection, I found that the code uses `setInterval` to continuously fetch status data.

Here's the code in `src/App.vue#L390`:

```js
    } else {
      this.mode = "dashboard";
      this.intervalHandler = window.setInterval(
        function () {
          this.getStatus();
        }.bind(this),
```

This does not fetch the data immediately when the page loads, causing the 5-second delay.

This PR includes a simple patch to execute `getStatus()` as soon as the page loads, which should resolve the issue.

[``](https://github.com/user-attachments/assets/4ba752ad-a221-4664-aa04-469d703afdaa)

Thank you for considering this change!

Note: Team 1 member here. If this PR is merged, I would appreciate any points awarded for the contributions.